### PR TITLE
Remove DomainError.Unexpected

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.5"
+arrow = "1.1.1-alpha.58"
 arrowGradleConfig = "0.11.0"
 coroutines = "1.6.4"
 dokka = "1.8.10"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.1-alpha.58"
+arrow = "1.1.6-alpha.58"
 arrowGradleConfig = "0.11.0"
 coroutines = "1.6.4"
 dokka = "1.8.10"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.6-alpha.58"
+arrow = "1.1.6-alpha.59"
 arrowGradleConfig = "0.11.0"
 coroutines = "1.6.4"
 dokka = "1.8.10"

--- a/src/main/kotlin/io/github/nomisrev/DomainError.kt
+++ b/src/main/kotlin/io/github/nomisrev/DomainError.kt
@@ -2,10 +2,15 @@ package io.github.nomisrev
 
 import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
 
 sealed interface DomainError
 
 sealed interface ValidationError : DomainError
+
+@OptIn(ExperimentalSerializationApi::class)
+data class IncorrectJson(val exception: MissingFieldException) : ValidationError
 
 data class EmptyUpdate(val description: String) : ValidationError
 
@@ -32,5 +37,3 @@ data class JwtInvalid(val description: String) : JwtError
 sealed interface ArticleError : DomainError
 
 data class CannotGenerateSlug(val description: String) : ArticleError
-
-data class Unexpected(val description: String, val error: Throwable) : UserError

--- a/src/main/kotlin/io/github/nomisrev/repo/ArticlePersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/ArticlePersistence.kt
@@ -1,7 +1,5 @@
 package io.github.nomisrev.repo
 
-import arrow.core.Either
-import io.github.nomisrev.Unexpected
 import io.github.nomisrev.service.Slug
 import io.github.nomisrev.sqldelight.ArticlesQueries
 import io.github.nomisrev.sqldelight.TagsQueries
@@ -21,10 +19,10 @@ interface ArticlePersistence {
     createdAt: OffsetDateTime,
     updatedAt: OffsetDateTime,
     tags: Set<String>
-  ): Either<Unexpected, ArticleId>
+  ): ArticleId
 
   /** Verifies if a certain slug already exists or not */
-  suspend fun exists(slug: Slug): Either<Unexpected, Boolean>
+  suspend fun exists(slug: Slug): Boolean
 }
 
 fun articleRepo(articles: ArticlesQueries, tagsQueries: TagsQueries) =
@@ -38,30 +36,18 @@ fun articleRepo(articles: ArticlesQueries, tagsQueries: TagsQueries) =
       createdAt: OffsetDateTime,
       updatedAt: OffsetDateTime,
       tags: Set<String>
-    ): Either<Unexpected, ArticleId> =
-      Either.catch {
-          articles.transactionWithResult<ArticleId> {
-            val articleId =
-              articles
-                .insertAndGetId(
-                  slug.value,
-                  title,
-                  description,
-                  body,
-                  authorId,
-                  createdAt,
-                  updatedAt
-                )
-                .executeAsOne()
+    ): ArticleId =
+      articles.transactionWithResult {
+        val articleId =
+          articles
+            .insertAndGetId(slug.value, title, description, body, authorId, createdAt, updatedAt)
+            .executeAsOne()
 
-            tags.forEach { tag -> tagsQueries.insert(articleId, tag) }
+        tags.forEach { tag -> tagsQueries.insert(articleId, tag) }
 
-            articleId
-          }
-        }
-        .mapLeft { e -> Unexpected("Failed to create article: $authorId:$title:$tags", e) }
+        articleId
+      }
 
-    override suspend fun exists(slug: Slug): Either<Unexpected, Boolean> =
-      Either.catch { articles.slugExists(slug.value).executeAsOne() }
-        .mapLeft { e -> Unexpected("Failed to check existence of $slug", e) }
+    override suspend fun exists(slug: Slug): Boolean =
+      articles.slugExists(slug.value).executeAsOne()
   }

--- a/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
@@ -7,7 +7,6 @@ import io.github.nomisrev.DomainError
 import io.github.nomisrev.PasswordNotMatched
 import io.github.nomisrev.UserNotFound
 import io.github.nomisrev.UsernameAlreadyExists
-import io.github.nomisrev.routes.catchOrThrow
 import io.github.nomisrev.service.UserInfo
 import io.github.nomisrev.sqldelight.UsersQueries
 import java.util.UUID

--- a/src/main/kotlin/io/github/nomisrev/routes/error.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/error.kt
@@ -58,6 +58,3 @@ suspend fun PipelineContext<Unit, ApplicationCall>.respond(error: DomainError): 
 private suspend inline fun PipelineContext<Unit, ApplicationCall>.unprocessable(
   error: String
 ): Unit = call.respond(HttpStatusCode.UnprocessableEntity, GenericErrorModel(error))
-
-private suspend inline fun PipelineContext<Unit, ApplicationCall>.internal(error: String): Unit =
-  call.respond(HttpStatusCode.InternalServerError, GenericErrorModel(error))

--- a/src/main/kotlin/io/github/nomisrev/routes/users.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/users.kt
@@ -2,8 +2,6 @@ package io.github.nomisrev.routes
 
 import arrow.core.Either
 import arrow.core.continuations.either
-import arrow.core.left
-import arrow.core.right
 import io.github.nomisrev.IncorrectJson
 import io.github.nomisrev.auth.jwtAuth
 import io.github.nomisrev.service.JwtService
@@ -99,14 +97,6 @@ fun Application.userRoutes(
     }
   }
 }
-
-// TODO bump to 1.1.6-alpha.6x and remove
-inline fun <reified T : Throwable, A> Either.Companion.catchOrThrow(block: () -> A): Either<T, A> =
-  try {
-    block().right()
-  } catch (e: Throwable) {
-    if (e is T) e.left() else throw e
-  }
 
 // TODO improve how we receive models with validation
 @OptIn(ExperimentalSerializationApi::class)

--- a/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
@@ -32,9 +32,7 @@ fun articleService(
     override suspend fun createArticle(input: CreateArticle): Either<DomainError, Article> =
       either {
         val slug =
-          slugGenerator
-            .generateSlug(input.title) { slug -> articlePersistence.exists(slug).bind() }
-            .bind()
+          slugGenerator.generateSlug(input.title) { slug -> articlePersistence.exists(slug) }.bind()
         val createdAt = OffsetDateTime.now()
         val articleId =
           articlePersistence
@@ -48,7 +46,6 @@ fun articleService(
               createdAt,
               input.tags
             )
-            .bind()
             .serial
         val user = userPersistence.select(input.userId).bind()
         Article(


### PR DESCRIPTION
This PR removes `DomainError.Unexpected` , and leaves this to be _truly exceptional_ modelled with `Throwable`.

Ktor, and other frameworks, automatically take care of truly exceptional cases and return `500 Internal Server Error` in this case. Be sure to add proper metric and logging systems such that you can track these kind of errors in production.

As you can see in this PR, `receiveCatching` was updated to properly deal with incorrect Json as this is an error we care to track, and respond with a different error than 500.

Making this code simplifies code in a couple of places, and follows YAGNI rationale.