### PR TITLE
Update deprecated code with either

### DIFF
--- a/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
@@ -1,8 +1,9 @@
 package io.github.nomisrev.repo
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
 import io.github.nomisrev.DomainError
 import io.github.nomisrev.PasswordNotMatched
 import io.github.nomisrev.UserNotFound

--- a/src/main/kotlin/io/github/nomisrev/routes/users.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/users.kt
@@ -1,7 +1,7 @@
 package io.github.nomisrev.routes
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import io.github.nomisrev.IncorrectJson
 import io.github.nomisrev.auth.jwtAuth
 import io.github.nomisrev.service.JwtService

--- a/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
@@ -1,7 +1,7 @@
 package io.github.nomisrev.service
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
 import io.github.nomisrev.DomainError
 import io.github.nomisrev.repo.ArticlePersistence
 import io.github.nomisrev.repo.UserId

--- a/src/main/kotlin/io/github/nomisrev/service/JwtService.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/JwtService.kt
@@ -1,8 +1,9 @@
 package io.github.nomisrev.service
 
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
 import io.github.nefilim.kjwt.JWSAlgorithm
 import io.github.nefilim.kjwt.JWSHMAC512Algorithm
 import io.github.nefilim.kjwt.JWT

--- a/src/main/kotlin/io/github/nomisrev/service/SlugGenerator.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/SlugGenerator.kt
@@ -1,8 +1,9 @@
 package io.github.nomisrev.service
 
 import arrow.core.Either
-import arrow.core.continuations.EffectScope
-import arrow.core.continuations.either
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+import arrow.core.raise.ensure
 import com.github.slugify.Slugify
 import io.github.nomisrev.CannotGenerateSlug
 import kotlin.random.Random
@@ -35,7 +36,7 @@ fun slugifyGenerator(
     private fun makeUnique(slug: String): String =
       "${slug}_${random.nextInt(minRandomSuffix, maxRandomSuffix)}"
 
-    private tailrec suspend fun EffectScope<CannotGenerateSlug>.recursiveGen(
+    private tailrec suspend fun Raise<CannotGenerateSlug>.recursiveGen(
       title: String,
       verifyUnique: suspend (Slug) -> Boolean,
       maxAttempts: Int,

--- a/src/main/kotlin/io/github/nomisrev/service/UserService.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/UserService.kt
@@ -1,7 +1,8 @@
 package io.github.nomisrev.service
 
 import arrow.core.Either
-import arrow.core.continuations.either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
 import io.github.nomisrev.DomainError
 import io.github.nomisrev.EmptyUpdate
 import io.github.nomisrev.auth.JwtToken


### PR DESCRIPTION
According to documentation, 
> The either DSL has been moved to arrow.core.raise.either.

This PR updates this template to follow the guidelines
