### PR TITLE
Ktor: type safe routing

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -46,6 +46,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 ktor-server-tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
 ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
+ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
@@ -75,7 +76,8 @@ ktor-server = [
     "ktor-server-defaultheaders",
     "ktor-server-netty",
     "ktor-server-auth",
-    "ktor-serialization"
+    "ktor-serialization",
+    "ktor-server-resources"
 ]
 ktor-client = [
     "ktor-client-content-negotiation",

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -51,6 +51,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-resources = { module = "io.ktor:ktor-client-resources", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-html = { module = "io.ktor:ktor-server-html-builder", version.ref = "ktor" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
@@ -81,7 +82,8 @@ ktor-server = [
 ]
 ktor-client = [
     "ktor-client-content-negotiation",
-    "ktor-client-serialization"
+    "ktor-client-serialization",
+    "ktor-client-resources"
 ]
 kotest = [
     "kotest-assertionsCore",

--- a/src/main/kotlin/io/github/nomisrev/env/ktor.kt
+++ b/src/main/kotlin/io/github/nomisrev/env/ktor.kt
@@ -10,6 +10,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.maxAgeDuration
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import io.ktor.server.resources.Resources
 import kotlin.time.Duration.Companion.days
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -22,6 +23,7 @@ val kotlinXSerializersModule = SerializersModule {
 
 fun Application.configure() {
   install(DefaultHeaders)
+  install(Resources) { serializersModule = kotlinXSerializersModule }
   install(ContentNegotiation) {
     json(
       Json {

--- a/src/main/kotlin/io/github/nomisrev/main.kt
+++ b/src/main/kotlin/io/github/nomisrev/main.kt
@@ -11,6 +11,7 @@ import io.github.nomisrev.routes.health
 import io.github.nomisrev.routes.userRoutes
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
 import kotlinx.coroutines.awaitCancellation
 
 fun main(): Unit = SuspendApp {
@@ -24,6 +25,6 @@ fun main(): Unit = SuspendApp {
 
 fun Application.app(module: Dependencies) {
   configure()
-  userRoutes(module.userService, module.jwtService)
+  routing { userRoutes(module.userService, module.jwtService) }
   health(module.healthCheck)
 }

--- a/src/test/kotlin/io/github/nomisrev/ktor.kt
+++ b/src/test/kotlin/io/github/nomisrev/ktor.kt
@@ -6,6 +6,7 @@ import io.github.nomisrev.env.Dependencies
 import io.github.nomisrev.env.kotlinXSerializersModule
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.resources.Resources
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.TestApplication
@@ -19,6 +20,7 @@ suspend fun withServer(test: suspend HttpClient.(dep: Dependencies) -> Unit): Un
     createClient {
         expectSuccess = false
         install(ContentNegotiation) { json(Json { serializersModule = kotlinXSerializersModule }) }
+        install(Resources) { serializersModule = kotlinXSerializersModule }
       }
       .use { client -> test(client, dependencies) }
   }

--- a/src/test/kotlin/io/github/nomisrev/routes/UserRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/UserRouteSpec.kt
@@ -6,10 +6,10 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
+import io.ktor.client.plugins.resources.get
+import io.ktor.client.plugins.resources.post
+import io.ktor.client.plugins.resources.put
 import io.ktor.client.request.bearerAuth
-import io.ktor.client.request.get
-import io.ktor.client.request.post
-import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -24,7 +24,7 @@ class UserRouteSpec :
     "Can register user" {
       withServer {
         val response =
-          post("/users") {
+          post(UsersResource) {
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(NewUser(validUsername, validEmail, validPw)))
           }
@@ -46,7 +46,7 @@ class UserRouteSpec :
           .shouldBeRight()
 
         val response =
-          post("/users/login") {
+          post(UsersResource.Login()) {
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(LoginUser(validEmail, validPw)))
           }
@@ -68,7 +68,7 @@ class UserRouteSpec :
             .register(RegisterUser(validUsername, validEmail, validPw))
             .shouldBeRight()
 
-        val response = get("/user") { bearerAuth(expected.value) }
+        val response = get(UserResource) { bearerAuth(expected.value) }
 
         response.status shouldBe HttpStatusCode.OK
         with(response.body<UserWrapper<User>>().user) {
@@ -90,7 +90,7 @@ class UserRouteSpec :
         val newUsername = "newUsername"
 
         val response =
-          put("/user") {
+          put(UserResource) {
             bearerAuth(expected.value)
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(UpdateUser(username = newUsername)))
@@ -116,7 +116,7 @@ class UserRouteSpec :
         val inalidEmail = "invalidEmail"
 
         val response =
-          put("/user") {
+          put(UserResource) {
             bearerAuth(token.value)
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(UpdateUser(email = inalidEmail)))


### PR DESCRIPTION
[resolves #170]
Boo! 🎃 

* moved top-level `routing { }` block to `app()` - `Application.userRoutes` becomes `Routes.userRoutes`
* code comments were erroneously prefixed with `/api`, though the API specification points to `/api` - but fixing this is for another PR
* (out-of-scope) it probably makes sense to extract models out of `users.kt` at some point, a bigger route handler might become claustrophobic

All in all, Ktor type-safe routing feels good, albeit a bit cumbersome with the annotations and especially having to declare the parent of a sub-route. I'd also love to optionally map the body in the resource definition somehow, before it hits the route handler and receive it in the lambda, like with query parameters - but that might get too complicated/specific. And then to tie that in with the validation plugin and so on.

Happy Hacktoberfest!