### PR TITLE
Add /api/ prefix to routes

### DIFF
--- a/src/main/kotlin/io/github/nomisrev/main.kt
+++ b/src/main/kotlin/io/github/nomisrev/main.kt
@@ -8,11 +8,9 @@ import io.github.nomisrev.env.Env
 import io.github.nomisrev.env.configure
 import io.github.nomisrev.env.dependencies
 import io.github.nomisrev.routes.health
-import io.github.nomisrev.routes.tagRoutes
-import io.github.nomisrev.routes.userRoutes
+import io.github.nomisrev.routes.routes
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
-import io.ktor.server.routing.routing
 import kotlinx.coroutines.awaitCancellation
 
 fun main(): Unit = SuspendApp {
@@ -26,7 +24,6 @@ fun main(): Unit = SuspendApp {
 
 fun Application.app(module: Dependencies) {
   configure()
-  routing { userRoutes(module.userService, module.jwtService) }
+  routes(module)
   health(module.healthCheck)
-  tagRoutes(module.tagPersistence)
 }

--- a/src/main/kotlin/io/github/nomisrev/routes/root.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/root.kt
@@ -1,0 +1,13 @@
+package io.github.nomisrev.routes
+
+import io.github.nomisrev.env.Dependencies
+import io.ktor.resources.Resource
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+
+fun Application.routes(deps: Dependencies) = routing {
+  userRoutes(deps.userService, deps.jwtService)
+  tagRoutes(deps.tagPersistence)
+}
+
+@Resource("/api") data object RootResource

--- a/src/main/kotlin/io/github/nomisrev/routes/tags.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/tags.kt
@@ -3,18 +3,17 @@
 package io.github.nomisrev.routes
 
 import io.github.nomisrev.repo.TagPersistence
-import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
-import io.ktor.server.routing.routing
 import kotlinx.serialization.Serializable
 
 @Serializable data class TagsResponse(val tags: List<String>)
 
-fun Application.tagRoutes(tagPersistence: TagPersistence) = routing {
-  route("/tags") {
+fun Route.tagRoutes(tagPersistence: TagPersistence) {
+  route("/api/tags") {
     /* Registration: GET /api/tags */
     get {
       val tags = tagPersistence.selectTags()

--- a/src/main/kotlin/io/github/nomisrev/routes/tags.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/tags.kt
@@ -3,21 +3,20 @@
 package io.github.nomisrev.routes
 
 import io.github.nomisrev.repo.TagPersistence
+import io.ktor.resources.Resource
 import io.ktor.server.application.call
+import io.ktor.server.resources.get
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.get
-import io.ktor.server.routing.route
 import kotlinx.serialization.Serializable
 
 @Serializable data class TagsResponse(val tags: List<String>)
 
+@Resource("/tags") data class TagsResource(val parent: RootResource = RootResource)
+
 fun Route.tagRoutes(tagPersistence: TagPersistence) {
-  route("/api/tags") {
-    /* Registration: GET /api/tags */
-    get {
-      val tags = tagPersistence.selectTags()
-      call.respond(TagsResponse(tags))
-    }
+  get<TagsResource> {
+    val tags = tagPersistence.selectTags()
+    call.respond(TagsResponse(tags))
   }
 }

--- a/src/test/kotlin/io/github/nomisrev/routes/TagRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/TagRouteSpec.kt
@@ -13,7 +13,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
-import io.ktor.client.request.get
+import io.ktor.client.plugins.resources.get
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -32,7 +32,7 @@ class TagRouteSpec :
 
     "Check for empty list retrieval" {
       withServer {
-        val response = get("/api/tags") { contentType(ContentType.Application.Json) }
+        val response = get(TagsResource()) { contentType(ContentType.Application.Json) }
 
         response.status shouldBe HttpStatusCode.OK
         response.body<TagsResponse>().tags.toSet() shouldBe emptySet()
@@ -54,7 +54,7 @@ class TagRouteSpec :
           )
           .shouldBeRight()
 
-        val response = get("/api/tags") { contentType(ContentType.Application.Json) }
+        val response = get(TagsResource()) { contentType(ContentType.Application.Json) }
 
         response.status shouldBe HttpStatusCode.OK
         response.body<TagsResponse>().tags shouldHaveSize 4

--- a/src/test/kotlin/io/github/nomisrev/routes/TagRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/TagRouteSpec.kt
@@ -32,7 +32,7 @@ class TagRouteSpec :
 
     "Check for empty list retrieval" {
       withServer {
-        val response = get("/tags") { contentType(ContentType.Application.Json) }
+        val response = get("/api/tags") { contentType(ContentType.Application.Json) }
 
         response.status shouldBe HttpStatusCode.OK
         response.body<TagsResponse>().tags.toSet() shouldBe emptySet()
@@ -54,7 +54,7 @@ class TagRouteSpec :
           )
           .shouldBeRight()
 
-        val response = get("/tags") { contentType(ContentType.Application.Json) }
+        val response = get("/api/tags") { contentType(ContentType.Application.Json) }
 
         response.status shouldBe HttpStatusCode.OK
         response.body<TagsResponse>().tags shouldHaveSize 4

--- a/src/test/kotlin/io/github/nomisrev/routes/UserRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/UserRouteSpec.kt
@@ -24,7 +24,7 @@ class UserRouteSpec :
     "Can register user" {
       withServer {
         val response =
-          post(UsersResource) {
+          post(UsersResource()) {
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(NewUser(validUsername, validEmail, validPw)))
           }
@@ -68,7 +68,7 @@ class UserRouteSpec :
             .register(RegisterUser(validUsername, validEmail, validPw))
             .shouldBeRight()
 
-        val response = get(UserResource) { bearerAuth(expected.value) }
+        val response = get(UserResource()) { bearerAuth(expected.value) }
 
         response.status shouldBe HttpStatusCode.OK
         with(response.body<UserWrapper<User>>().user) {
@@ -90,7 +90,7 @@ class UserRouteSpec :
         val newUsername = "newUsername"
 
         val response =
-          put(UserResource) {
+          put(UserResource()) {
             bearerAuth(expected.value)
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(UpdateUser(username = newUsername)))
@@ -116,7 +116,7 @@ class UserRouteSpec :
         val inalidEmail = "invalidEmail"
 
         val response =
-          put(UserResource) {
+          put(UserResource()) {
             bearerAuth(token.value)
             contentType(ContentType.Application.Json)
             setBody(UserWrapper(UpdateUser(email = inalidEmail)))


### PR DESCRIPTION
Closes #181 - options discussed further in the ticket

* all routes are now prefixed with `/api/`
  * for resource-based routes, a `RootResource` was added and should be used as the parent for all routes
  * for string-based routes, routes are updated
* moved routing wire-up into its own function to keep the main class reasonable
  * should probably make `RouteDependencies` or something instead of passing `Dependencies` in the future