### PR TITLE
POST follow profile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ ktor {
 spotless {
   kotlin {
     targetExclude("**/build/**")
-    ktfmt().googleStyle()
+    ktfmt("0.46").googleStyle()
   }
 }
 

--- a/src/main/kotlin/io/github/nomisrev/auth/jwt.kt
+++ b/src/main/kotlin/io/github/nomisrev/auth/jwt.kt
@@ -39,8 +39,7 @@ suspend inline fun PipelineContext<Unit, ApplicationCall>.optionalJwtAuth(
         { error -> respond(error) },
         { userId -> body(this, JwtContext(JwtToken(token), userId)) }
       )
-  }
-    ?: body(this, null)
+  } ?: body(this, null)
 }
 
 fun PipelineContext<Unit, ApplicationCall>.jwtToken(): String? =

--- a/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
@@ -45,7 +45,7 @@ interface UserPersistence {
     image: String?
   ): Either<DomainError, UserInfo>
 
-  suspend fun unfollowProfile(followedUsername: String, followerId: UserId): Unit
+  suspend fun unfollowProfile(followedUsername: String, followerId: UserId)
 }
 
 /** UserPersistence implementation based on SqlDelight and JavaX Crypto */
@@ -128,10 +128,8 @@ fun userPersistence(
       ensureNotNull(info) { UserNotFound("userId=$userId") }
     }
 
-    override suspend fun unfollowProfile(
-      followedUsername: String,
-      followerId: UserId
-    ): Unit = followingQueries.delete(followedUsername, followerId.serial)
+    override suspend fun unfollowProfile(followedUsername: String, followerId: UserId): Unit =
+      followingQueries.delete(followedUsername, followerId.serial)
 
     private fun generateSalt(): ByteArray = UUID.randomUUID().toString().toByteArray()
 

--- a/src/main/kotlin/io/github/nomisrev/routes/articles.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/articles.kt
@@ -49,14 +49,6 @@ data class MultipleArticlesResponse(
 @JvmInline @Serializable value class FeedLimit(val limit: Int)
 
 @Serializable
-data class Profile(
-  val username: String,
-  val bio: String,
-  val image: String,
-  val following: Boolean
-)
-
-@Serializable
 data class Comment(
   val commentId: Long,
   @Serializable(with = OffsetDateTimeIso8601Serializer::class) val createdAt: OffsetDateTime,

--- a/src/main/kotlin/io/github/nomisrev/routes/error.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/error.kt
@@ -29,7 +29,6 @@ fun GenericErrorModel(vararg msg: String): GenericErrorModel =
   GenericErrorModel(GenericErrorModelErrors(msg.toList()))
 
 context(PipelineContext<Unit, ApplicationCall>)
-
 suspend inline fun <reified A : Any> Either<DomainError, A>.respond(status: HttpStatusCode): Unit =
   when (this) {
     is Either.Left -> respond(value)

--- a/src/main/kotlin/io/github/nomisrev/routes/profile.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/profile.kt
@@ -8,11 +8,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource
 import io.ktor.server.resources.delete
 import io.ktor.server.routing.Route
-
 import kotlinx.serialization.Serializable
 
-@Serializable
-data class ProfileWrapper<T : Any>(val profile: T)
+@Serializable data class ProfileWrapper<T : Any>(val profile: T)
 
 @Serializable
 data class Profile(
@@ -28,17 +26,17 @@ data class ProfilesResource(val parent: RootResource = RootResource) {
   data class Follow(val parent: ProfilesResource = ProfilesResource(), val username: String)
 }
 
-fun Route.profileRoutes(
-  userPersistence: UserPersistence,
-  jwtService: JwtService
-) {
+fun Route.profileRoutes(userPersistence: UserPersistence, jwtService: JwtService) {
   delete<ProfilesResource.Follow> { follow ->
     jwtAuth(jwtService) { (_, userId) ->
       either {
-        userPersistence.unfollowProfile(follow.username, userId)
-        val userUnfollowed =  userPersistence.select(follow.username).bind()
-        ProfileWrapper(Profile(userUnfollowed.username, userUnfollowed.bio, userUnfollowed.image, false))
-      }.respond(HttpStatusCode.OK)
+          userPersistence.unfollowProfile(follow.username, userId)
+          val userUnfollowed = userPersistence.select(follow.username).bind()
+          ProfileWrapper(
+            Profile(userUnfollowed.username, userUnfollowed.bio, userUnfollowed.image, false)
+          )
+        }
+        .respond(HttpStatusCode.OK)
     }
   }
 }

--- a/src/main/kotlin/io/github/nomisrev/routes/profile.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/profile.kt
@@ -11,8 +11,8 @@ import io.github.nomisrev.service.JwtService
 import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource
 import io.ktor.server.resources.delete
-import io.ktor.server.resources.post
 import io.ktor.server.resources.get
+import io.ktor.server.resources.post
 import io.ktor.server.routing.Route
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/github/nomisrev/routes/profile.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/profile.kt
@@ -7,6 +7,7 @@ import io.github.nomisrev.service.JwtService
 import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource
 import io.ktor.server.resources.delete
+import io.ktor.server.resources.post
 import io.ktor.server.routing.Route
 import kotlinx.serialization.Serializable
 
@@ -35,6 +36,16 @@ fun Route.profileRoutes(userPersistence: UserPersistence, jwtService: JwtService
           ProfileWrapper(
             Profile(userUnfollowed.username, userUnfollowed.bio, userUnfollowed.image, false)
           )
+        }
+        .respond(HttpStatusCode.OK)
+    }
+  }
+  post<ProfilesResource.Follow> { follow ->
+    jwtAuth(jwtService) { (_, userId) ->
+      either {
+          userPersistence.followProfile(follow.username, userId)
+          val userFollowed = userPersistence.select(follow.username).bind()
+          ProfileWrapper(Profile(userFollowed.username, userFollowed.bio, userFollowed.image, true))
         }
         .respond(HttpStatusCode.OK)
     }

--- a/src/main/sqldelight/io/github/nomisrev/sqldelight/Following.sq
+++ b/src/main/sqldelight/io/github/nomisrev/sqldelight/Following.sq
@@ -18,6 +18,10 @@ insert:
 INSERT INTO following(followed_id, follower_id)
 VALUES (:followedId, :followerId);
 
+insertByUsername:
+INSERT INTO following(followed_id, follower_id)
+VALUES ((SELECT id FROM users WHERE users.username=:username), :followerId);
+
 delete:
 DELETE FROM following
 WHERE followed_id=(SELECT id FROM users WHERE users.username=:username) AND follower_id = :followerId;

--- a/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.resources.delete
+import io.ktor.client.plugins.resources.post
 import io.ktor.client.request.bearerAuth
 import io.ktor.http.HttpStatusCode
 
@@ -17,6 +18,31 @@ class ProfileRouteSpec :
     val validPw = "123456789"
     val validUsernameFollowed = "username2"
     val validEmailFollowed = "valid2@domain.com"
+
+    "Can follow profile" {
+      withServer { dependencies ->
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
+        dependencies.userService
+          .register(RegisterUser(validUsernameFollowed, validEmailFollowed, validPw))
+          .shouldBeRight()
+
+        val response =
+          post(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
+
+        response.status shouldBe HttpStatusCode.OK
+        with(response.body<ProfileWrapper<Profile>>().profile) {
+          username shouldBe validUsernameFollowed
+          bio shouldBe ""
+          image shouldBe ""
+          following shouldBe true
+        }
+      }
+    }
 
     "Can unfollow profile" {
       withServer { dependencies ->
@@ -43,11 +69,35 @@ class ProfileRouteSpec :
       }
     }
 
+    "Needs token to follow" {
+      withServer {
+        val response = post(ProfilesResource.Follow(username = validUsernameFollowed))
+
+        response.status shouldBe HttpStatusCode.Unauthorized
+      }
+    }
+
     "Needs token to unfollow" {
       withServer {
         val response = delete(ProfilesResource.Follow(username = validUsernameFollowed))
 
         response.status shouldBe HttpStatusCode.Unauthorized
+      }
+    }
+
+    "Username invalid to follow" {
+      withServer { dependencies ->
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
+
+        val response =
+          post(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
+
+        response.status shouldBe HttpStatusCode.UnprocessableEntity
       }
     }
 

--- a/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
@@ -8,8 +8,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.resources.delete
-import io.ktor.client.plugins.resources.post
 import io.ktor.client.plugins.resources.get
+import io.ktor.client.plugins.resources.post
 import io.ktor.client.request.bearerAuth
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode

--- a/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
@@ -6,8 +6,8 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.plugins.resources.delete
+import io.ktor.client.request.bearerAuth
 import io.ktor.http.HttpStatusCode
 
 class ProfileRouteSpec :
@@ -20,16 +20,18 @@ class ProfileRouteSpec :
 
     "Can unfollow profile" {
       withServer { dependencies ->
-        val token = dependencies.userService
-          .register(RegisterUser(validUsername, validEmail, validPw))
-          .shouldBeRight()
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
         dependencies.userService
           .register(RegisterUser(validUsernameFollowed, validEmailFollowed, validPw))
           .shouldBeRight()
 
-        val response = delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
-          bearerAuth(token.value)
-        }
+        val response =
+          delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
 
         response.status shouldBe HttpStatusCode.OK
         with(response.body<ProfileWrapper<Profile>>().profile) {
@@ -50,14 +52,16 @@ class ProfileRouteSpec :
     }
 
     "Username invalid to unfollow" {
-      withServer {dependencies ->
-        val token = dependencies.userService
-          .register(RegisterUser(validUsername, validEmail, validPw))
-          .shouldBeRight()
+      withServer { dependencies ->
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
 
-        val response = delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
-          bearerAuth(token.value)
-        }
+        val response =
+          delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
 
         response.status shouldBe HttpStatusCode.UnprocessableEntity
       }


### PR DESCRIPTION
[closes #155]

* Build was not passing as `Profile` was declared twice, and because of style violations
* I had to explicitly use a newer version of `ktfmt` to make the format check pass with a context receiver inside an interface. If that's not desirable, I can go with a more traditional way 🙂 

Does it make sense to create a ticket for checking if the user A is already following user B? Currently, you can follow/unfollow irrespective of the existing state.