### PR TITLE
Fix duplicate `Profile`

### DIFF
--- a/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/UserPersistence.kt
@@ -128,10 +128,8 @@ fun userPersistence(
       ensureNotNull(info) { UserNotFound("userId=$userId") }
     }
 
-    override suspend fun unfollowProfile(
-      followedUsername: String,
-      followerId: UserId
-    ): Unit = followingQueries.delete(followedUsername, followerId.serial)
+    override suspend fun unfollowProfile(followedUsername: String, followerId: UserId): Unit =
+      followingQueries.delete(followedUsername, followerId.serial)
 
     private fun generateSalt(): ByteArray = UUID.randomUUID().toString().toByteArray()
 

--- a/src/main/kotlin/io/github/nomisrev/routes/articles.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/articles.kt
@@ -49,14 +49,6 @@ data class MultipleArticlesResponse(
 @JvmInline @Serializable value class FeedLimit(val limit: Int)
 
 @Serializable
-data class Profile(
-  val username: String,
-  val bio: String,
-  val image: String,
-  val following: Boolean
-)
-
-@Serializable
 data class Comment(
   val commentId: Long,
   @Serializable(with = OffsetDateTimeIso8601Serializer::class) val createdAt: OffsetDateTime,

--- a/src/main/kotlin/io/github/nomisrev/routes/profile.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/profile.kt
@@ -8,11 +8,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource
 import io.ktor.server.resources.delete
 import io.ktor.server.routing.Route
-
 import kotlinx.serialization.Serializable
 
-@Serializable
-data class ProfileWrapper<T : Any>(val profile: T)
+@Serializable data class ProfileWrapper<T : Any>(val profile: T)
 
 @Serializable
 data class Profile(
@@ -28,17 +26,17 @@ data class ProfilesResource(val parent: RootResource = RootResource) {
   data class Follow(val parent: ProfilesResource = ProfilesResource(), val username: String)
 }
 
-fun Route.profileRoutes(
-  userPersistence: UserPersistence,
-  jwtService: JwtService
-) {
+fun Route.profileRoutes(userPersistence: UserPersistence, jwtService: JwtService) {
   delete<ProfilesResource.Follow> { follow ->
     jwtAuth(jwtService) { (_, userId) ->
       either {
-        userPersistence.unfollowProfile(follow.username, userId)
-        val userUnfollowed =  userPersistence.select(follow.username).bind()
-        ProfileWrapper(Profile(userUnfollowed.username, userUnfollowed.bio, userUnfollowed.image, false))
-      }.respond(HttpStatusCode.OK)
+          userPersistence.unfollowProfile(follow.username, userId)
+          val userUnfollowed = userPersistence.select(follow.username).bind()
+          ProfileWrapper(
+            Profile(userUnfollowed.username, userUnfollowed.bio, userUnfollowed.image, false)
+          )
+        }
+        .respond(HttpStatusCode.OK)
     }
   }
 }

--- a/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
+++ b/src/test/kotlin/io/github/nomisrev/routes/ProfileRouteSpec.kt
@@ -6,8 +6,8 @@ import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.plugins.resources.delete
+import io.ktor.client.request.bearerAuth
 import io.ktor.http.HttpStatusCode
 
 class ProfileRouteSpec :
@@ -20,16 +20,18 @@ class ProfileRouteSpec :
 
     "Can unfollow profile" {
       withServer { dependencies ->
-        val token = dependencies.userService
-          .register(RegisterUser(validUsername, validEmail, validPw))
-          .shouldBeRight()
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
         dependencies.userService
           .register(RegisterUser(validUsernameFollowed, validEmailFollowed, validPw))
           .shouldBeRight()
 
-        val response = delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
-          bearerAuth(token.value)
-        }
+        val response =
+          delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
 
         response.status shouldBe HttpStatusCode.OK
         with(response.body<ProfileWrapper<Profile>>().profile) {
@@ -50,14 +52,16 @@ class ProfileRouteSpec :
     }
 
     "Username invalid to unfollow" {
-      withServer {dependencies ->
-        val token = dependencies.userService
-          .register(RegisterUser(validUsername, validEmail, validPw))
-          .shouldBeRight()
+      withServer { dependencies ->
+        val token =
+          dependencies.userService
+            .register(RegisterUser(validUsername, validEmail, validPw))
+            .shouldBeRight()
 
-        val response = delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
-          bearerAuth(token.value)
-        }
+        val response =
+          delete(ProfilesResource.Follow(username = validUsernameFollowed)) {
+            bearerAuth(token.value)
+          }
 
         response.status shouldBe HttpStatusCode.UnprocessableEntity
       }


### PR DESCRIPTION
After merging Pablo's pull request, two conflicting `Profile` data classes were detected.

![Screenshot 2023-10-30 at 6 45 49 AM](https://github.com/nomisRev/ktor-arrow-example/assets/39463024/a37948c5-cd7c-4e11-b6fe-89259bc13948)

After making the necessary changes, I run the command `gradlew spotlessApply` to format the code.