### PR TITLE
Add support for article filtering with pagination and refactor article fetching logic

### DIFF
--- a/src/main/kotlin/io/github/nomisrev/Validation.kt
+++ b/src/main/kotlin/io/github/nomisrev/Validation.kt
@@ -12,10 +12,12 @@ import arrow.core.nonEmptyListOf
 import arrow.core.right
 import io.github.nomisrev.repo.UserId
 import io.github.nomisrev.routes.ArticleResource
+import io.github.nomisrev.routes.ArticlesResource
 import io.github.nomisrev.routes.FeedLimit
 import io.github.nomisrev.routes.FeedOffset
 import io.github.nomisrev.routes.NewArticle
 import io.github.nomisrev.routes.NewComment
+import io.github.nomisrev.service.GetArticles
 import io.github.nomisrev.service.GetFeed
 import io.github.nomisrev.service.Login
 import io.github.nomisrev.service.RegisterUser
@@ -192,5 +194,18 @@ fun Int.validFeedLimit(): Either<InvalidFeedLimit, FeedLimit> =
 fun ArticleResource.Feed.validate(userId: UserId): Either<IncorrectInput, GetFeed> =
     zipOrAccumulate(offsetParam.validFeedOffset(), limitParam.validFeedLimit()) { offset, limit ->
             GetFeed(userId, limit.limit, offset.offset)
+        }
+        .mapLeft(::IncorrectInput)
+
+fun ArticlesResource.validate(currentUserId: UserId?): Either<IncorrectInput, GetArticles> =
+    zipOrAccumulate(offsetParam.validFeedOffset(), limitParam.validFeedLimit()) { offset, limit ->
+            GetArticles(
+                limit = limit.limit,
+                offset = offset.offset,
+                author = author,
+                favorited = favorited,
+                tag = tag,
+                currentUserId = currentUserId,
+            )
         }
         .mapLeft(::IncorrectInput)

--- a/src/main/kotlin/io/github/nomisrev/repo/ArticlePersistence.kt
+++ b/src/main/kotlin/io/github/nomisrev/repo/ArticlePersistence.kt
@@ -4,7 +4,6 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
 import io.github.nomisrev.ArticleBySlugNotFound
-import io.github.nomisrev.routes.Article
 import io.github.nomisrev.routes.Comment
 import io.github.nomisrev.routes.FeedLimit
 import io.github.nomisrev.routes.FeedOffset
@@ -14,6 +13,11 @@ import io.github.nomisrev.sqldelight.*
 import java.time.OffsetDateTime
 
 @JvmInline value class ArticleId(val serial: Long)
+
+data class ArticleListResult(
+    val articles: List<Articles>,
+    val articlesCount: Long,
+)
 
 interface ArticlePersistence {
     @Suppress("LongParameterList")
@@ -33,7 +37,19 @@ interface ArticlePersistence {
     suspend fun exists(slug: Slug): Boolean
 
     /** Get recent articles from users you follow * */
-    suspend fun feed(userId: UserId, limit: FeedLimit, offset: FeedOffset): List<Article>
+    suspend fun feed(userId: UserId, limit: FeedLimit, offset: FeedOffset): List<Articles>
+
+    /** Total number of articles in the user's feed */
+    suspend fun feedCount(userId: UserId): Long
+
+    /** Get recent articles matching the optional filters */
+    suspend fun allArticles(
+        limit: FeedLimit,
+        offset: FeedOffset,
+        author: String? = null,
+        favorited: String? = null,
+        tag: String? = null,
+    ): ArticleListResult
 
     // TODO create proper domain for Articles
     suspend fun findArticleBySlug(slug: Slug): Either<ArticleBySlugNotFound, Articles>
@@ -110,7 +126,7 @@ fun articleRepo(articles: ArticlesQueries, comments: CommentsQueries, tagsQuerie
             userId: UserId,
             limit: FeedLimit,
             offset: FeedOffset,
-        ): List<Article> =
+        ): List<Articles> =
             articles
                 .selectFeedArticles(userId.serial, limit.limit.toLong(), offset.offset.toLong()) {
                     articleId,
@@ -118,28 +134,70 @@ fun articleRepo(articles: ArticlesQueries, comments: CommentsQueries, tagsQuerie
                     articleTitle,
                     articleDescription,
                     articleBody,
-                    _,
+                    articleAuthorId,
                     articleCreatedAt,
                     articleUpdatedAt,
                     _,
-                    usersUsername,
-                    usersBio,
-                    usersImage ->
-                    Article(
-                        articleId = articleId.serial,
+                    _,
+                    _,
+                    _ ->
+                    Articles(
+                        id = articleId,
                         slug = articleSlug,
                         title = articleTitle,
                         description = articleDescription,
                         body = articleBody,
-                        author = Profile(usersUsername, usersBio, usersImage, true),
-                        favorited = false,
-                        favoritesCount = 0,
+                        author_id = articleAuthorId,
                         createdAt = articleCreatedAt,
                         updatedAt = articleUpdatedAt,
-                        tagList = listOf(),
                     )
                 }
                 .executeAsList()
+
+        override suspend fun feedCount(userId: UserId): Long =
+            articles.countFeedArticles(userId.serial).executeAsOne()
+
+        override suspend fun allArticles(
+            limit: FeedLimit,
+            offset: FeedOffset,
+            author: String?,
+            favorited: String?,
+            tag: String?,
+        ): ArticleListResult {
+            val query =
+                when {
+                    !author.isNullOrBlank() ->
+                        articles.selectArticlesByAuthor(
+                            author,
+                            limit.limit.toLong(),
+                            offset.offset.toLong(),
+                        )
+                    !favorited.isNullOrBlank() ->
+                        articles.selectArticlesFavoritedByUsername(
+                            favorited,
+                            limit.limit.toLong(),
+                            offset.offset.toLong(),
+                        )
+                    !tag.isNullOrBlank() ->
+                        articles.selectArticlesByTag(
+                            tag,
+                            limit.limit.toLong(),
+                            offset.offset.toLong(),
+                        )
+                    else -> articles.selectAllArticles(limit.limit.toLong(), offset.offset.toLong())
+                }
+
+            val count =
+                when {
+                    !author.isNullOrBlank() -> articles.countArticlesByAuthor(author).executeAsOne()
+                    !favorited.isNullOrBlank() ->
+                        articles.countArticlesFavoritedByUsername(favorited).executeAsOne()
+                    !tag.isNullOrBlank() -> articles.countArticlesByTag(tag).executeAsOne()
+                    else -> articles.countAllArticles().executeAsOne()
+                }
+
+            return ArticleListResult(query.executeAsList(), count)
+        }
 
         override suspend fun findArticleBySlug(
             slug: Slug

--- a/src/main/kotlin/io/github/nomisrev/routes/articles.kt
+++ b/src/main/kotlin/io/github/nomisrev/routes/articles.kt
@@ -1,7 +1,6 @@
 package io.github.nomisrev.routes
 
 import arrow.core.Either
-import arrow.core.raise.context.bind
 import arrow.core.raise.either
 import io.github.nomisrev.IncorrectInput
 import io.github.nomisrev.auth.jwtAuth
@@ -117,7 +116,14 @@ data class ArticleResource(val parent: RootResource = RootResource) {
 }
 
 @Resource("/articles")
-data class ArticlesResource(val parent: RootResource = RootResource) {
+data class ArticlesResource(
+    val author: String? = null,
+    val favorited: String? = null,
+    val tag: String? = null,
+    val offsetParam: Int = 0,
+    val limitParam: Int = 20,
+    val parent: RootResource = RootResource,
+) {
     @Resource("{slug}")
     data class Slug(val parent: ArticlesResource = ArticlesResource(), val slug: String) {
         @Resource("favorite") data class Favorite(val parent: Slug)
@@ -130,7 +136,15 @@ data class ArticlesResource(val parent: RootResource = RootResource) {
 }
 
 fun Route.articleRoutes(articleService: ArticleService, jwtService: JwtService) {
-    get<ArticlesResource> { articleService.getAllArticles().respond(HttpStatusCode.OK) }
+    get<ArticlesResource> { articles ->
+        optionalJwtAuth(jwtService) { context ->
+            either {
+                    val input = articles.validate(currentUserId = context?.userId).bind()
+                    articleService.getAllArticles(input).bind()
+                }
+                .respond(HttpStatusCode.OK)
+        }
+    }
 
     get<ArticleResource.Feed> { feed ->
         jwtAuth(jwtService) { (_, userId) ->
@@ -143,9 +157,9 @@ fun Route.articleRoutes(articleService: ArticleService, jwtService: JwtService) 
     }
 
     get<ArticlesResource.Slug> { slug ->
-        optionalJwtAuth(jwtService) {
+        optionalJwtAuth(jwtService) { context ->
             articleService
-                .getArticleBySlug(Slug(slug.slug))
+                .getArticleBySlug(Slug(slug.slug), context?.userId)
                 .map { SingleArticleResponse(it) }
                 .respond(HttpStatusCode.OK)
         }

--- a/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
+++ b/src/main/kotlin/io/github/nomisrev/service/ArticleService.kt
@@ -1,7 +1,6 @@
 package io.github.nomisrev.service
 
 import arrow.core.Either
-import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
@@ -43,6 +42,15 @@ data class UpdateArticleInput(
 
 data class GetFeed(val userId: UserId, val limit: Int, val offset: Int)
 
+data class GetArticles(
+    val limit: Int,
+    val offset: Int,
+    val author: String? = null,
+    val favorited: String? = null,
+    val tag: String? = null,
+    val currentUserId: UserId? = null,
+)
+
 interface ArticleService {
     /** Creates a new article and returns the resulting Article */
     suspend fun createArticle(input: CreateArticle): Either<DomainError, Article>
@@ -51,10 +59,13 @@ interface ArticleService {
     suspend fun getUserFeed(input: GetFeed): MultipleArticlesResponse
 
     /** Get all articles */
-    suspend fun getAllArticles(): Either<DomainError, MultipleArticlesResponse>
+    suspend fun getAllArticles(input: GetArticles): Either<DomainError, MultipleArticlesResponse>
 
     /** Get article by Slug */
-    suspend fun getArticleBySlug(slug: Slug): Either<DomainError, Article>
+    suspend fun getArticleBySlug(
+        slug: Slug,
+        currentUserId: UserId? = null,
+    ): Either<DomainError, Article>
 
     /** Update an article and return the updated Article */
     suspend fun updateArticle(input: UpdateArticleInput): Either<DomainError, Article>
@@ -149,8 +160,7 @@ fun articleService(
                     .updateArticle(input.slug, input.title, input.description, input.body)
                     .bind()
 
-            val favorite = favouritePersistence.isFavorite(input.userId, article.id)
-            article(updatedArticle, favorite)
+            article(updatedArticle, input.userId)
         }
 
         override suspend fun getUserFeed(input: GetFeed): MultipleArticlesResponse {
@@ -161,20 +171,50 @@ fun articleService(
                     offset = FeedOffset(input.offset),
                 )
 
-            return MultipleArticlesResponse(articles = articles, articlesCount = articles.size)
-        }
+            val articlesCount = articlePersistence.feedCount(input.userId).toInt()
 
-        override suspend fun getAllArticles(): Either<DomainError, MultipleArticlesResponse> =
-            either {
-                // Since we don't have a method to get all articles, we'll return an empty list for
-                // now
-                MultipleArticlesResponse(articles = emptyList(), articlesCount = 0)
+            val responseArticles = mutableListOf<Article>()
+            for (articleRow in articles) {
+                responseArticles.add(article(articleRow, input.userId))
             }
 
-        override suspend fun getArticleBySlug(slug: Slug): Either<DomainError, Article> = either {
+            return MultipleArticlesResponse(
+                articles = responseArticles,
+                articlesCount = articlesCount,
+            )
+        }
+
+        override suspend fun getAllArticles(
+            input: GetArticles
+        ): Either<DomainError, MultipleArticlesResponse> = either {
+            val limit = FeedLimit(input.limit)
+            val offset = FeedOffset(input.offset)
+            val result =
+                articlePersistence.allArticles(
+                    limit = limit,
+                    offset = offset,
+                    author = input.author,
+                    favorited = input.favorited,
+                    tag = input.tag,
+                )
+
+            val responseArticles = mutableListOf<Article>()
+            for (articleRow in result.articles) {
+                responseArticles.add(article(articleRow, input.currentUserId))
+            }
+
+            MultipleArticlesResponse(
+                articles = responseArticles,
+                articlesCount = result.articlesCount.toInt(),
+            )
+        }
+
+        override suspend fun getArticleBySlug(
+            slug: Slug,
+            currentUserId: UserId?,
+        ): Either<DomainError, Article> = either {
             val article = articlePersistence.findArticleBySlug(slug).bind()
-            // TODO: optional auth route check if user favorited
-            article(article, false)
+            article(article, currentUserId)
         }
 
         override suspend fun insertCommentForArticleSlug(
@@ -182,7 +222,7 @@ fun articleService(
             userId: UserId,
             comment: String,
         ): Either<DomainError, Comments> = either {
-            val article = getArticleBySlug(slug).bind()
+            val article = getArticleBySlug(slug, userId).bind()
             articlePersistence.createCommentForArticleSlug(
                 slug,
                 userId,
@@ -214,7 +254,7 @@ fun articleService(
             val articleId = article.id
 
             favouritePersistence.favoriteArticle(userId, articleId)
-            article(article, true)
+            article(article, userId)
         }
 
         override suspend fun unfavoriteArticle(
@@ -224,16 +264,24 @@ fun articleService(
             val article = articlePersistence.findArticleBySlug(slug).bind()
             val articleId = article.id
             favouritePersistence.unfavoriteArticle(userId, articleId)
-            article(article, false)
+            article(article, userId)
         }
 
-        private suspend fun Raise<DomainError>.article(
+        private suspend fun article(
             article: Articles,
-            favorited: Boolean,
+            currentUserId: UserId?,
         ): Article {
-            val user = userPersistence.select(article.author_id).bind()
+            val user =
+                when (val selectedUser = userPersistence.select(article.author_id)) {
+                    is Either.Left -> error("Author ${article.author_id.serial} not found")
+                    is Either.Right -> selectedUser.value
+                }
             val articleTags = tagPersistence.selectTagsOfArticle(article.id)
             val favouriteCount = favouritePersistence.favoriteCount(article.id)
+            val favorited =
+                if (currentUserId != null)
+                    favouritePersistence.isFavorite(currentUserId, article.id)
+                else false
             return Article(
                 article.id.serial,
                 article.slug,

--- a/src/main/sqldelight/io/github/nomisrev/sqldelight/Articles.sq
+++ b/src/main/sqldelight/io/github/nomisrev/sqldelight/Articles.sq
@@ -71,10 +71,88 @@ DELETE FROM articles
 WHERE id = :articleId;
 
 selectAllArticles:
-SELECT
-articles.id AS article__id, articles.slug AS article__slug, articles.title AS article__title, articles.description AS article__description, articles.body AS article__body, articles.author_id AS article__author_id, articles.createdAt AS article__createdAt, articles.updatedAt AS article__updatedAt,
-users.id AS users__id, users.username AS users__username, users.bio AS users__bio, users.image AS users__image
+SELECT id, slug, title, description, body, author_id, createdAt, updatedAt
 FROM articles
-INNER JOIN users ON articles.author_id = users.id
 ORDER BY createdAt DESC
 LIMIT :limit OFFSET :offset;
+
+countAllArticles:
+SELECT COUNT(id)
+FROM articles;
+
+selectArticlesByAuthor:
+SELECT id, slug, title, description, body, author_id, createdAt, updatedAt
+FROM articles
+WHERE author_id IN (
+    SELECT id
+    FROM users
+    WHERE username = :username
+)
+ORDER BY createdAt DESC
+LIMIT :limit OFFSET :offset;
+
+countArticlesByAuthor:
+SELECT COUNT(id)
+FROM articles
+WHERE author_id IN (
+    SELECT id
+    FROM users
+    WHERE username = :username
+);
+
+selectArticlesByTag:
+SELECT id, slug, title, description, body, author_id, createdAt, updatedAt
+FROM articles
+WHERE id IN (
+    SELECT article_id
+    FROM tags
+    WHERE tag = :tag
+)
+ORDER BY createdAt DESC
+LIMIT :limit OFFSET :offset;
+
+countArticlesByTag:
+SELECT COUNT(id)
+FROM articles
+WHERE id IN (
+    SELECT article_id
+    FROM tags
+    WHERE tag = :tag
+);
+
+selectArticlesFavoritedByUsername:
+SELECT id, slug, title, description, body, author_id, createdAt, updatedAt
+FROM articles
+WHERE id IN (
+    SELECT article_id
+    FROM favorites
+    WHERE user_id IN (
+        SELECT id
+        FROM users
+        WHERE username = :username
+    )
+)
+ORDER BY createdAt DESC
+LIMIT :limit OFFSET :offset;
+
+countArticlesFavoritedByUsername:
+SELECT COUNT(id)
+FROM articles
+WHERE id IN (
+    SELECT article_id
+    FROM favorites
+    WHERE user_id IN (
+        SELECT id
+        FROM users
+        WHERE username = :username
+    )
+);
+
+countFeedArticles:
+SELECT COUNT(id)
+FROM articles
+WHERE author_id IN (
+    SELECT following.followed_id
+    FROM following
+    WHERE following.follower_id = :user_id
+);


### PR DESCRIPTION
- Introduced `GetArticles` request structure for handling article filters such as author, favorited, and tags.
- Updated SQL queries and persistence layers to support filtered and paginated article retrieval.
- Refactored routes and `ArticleService` to validate and process filtered input.
- Improved consistency and flexibility for article-related APIs.